### PR TITLE
Python API: move the `really_get_paths` function into the API

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -1,4 +1,4 @@
-import pyscion as sci
+import pyscion as scion
 import sys
 import time
 
@@ -7,25 +7,16 @@ MTU = 1300  # leave enough space for SCION headers
 
 
 def main():
-    sci.init()
-    print('Local Address is {}'.format(sci.local_address()))
+    scion.init()
+    print('Local Address is {}'.format(scion.local_address()))
     for dest_addr, nbytes in parse_tasks_from_stdin():
         destination = "{}:12345".format(dest_addr) # send to port 12345
         print(' === TASK to destination {} : {}MB ==='.format(destination, int(nbytes/1024/1024)))
-        paths = really_get_paths(destination)
-        print('Got %d paths' % len(paths))
-        with sci.connect(destination, paths[0]) as fd:
+        paths = scion.get_paths(destination)
+        print('Got {} paths'.format(len(paths)))
+        with scion.connect(destination, paths[0]) as fd:
             for i in range(int(nbytes / 1000)+1):
                 fd.write(MTU*b'a')
-
-
-def really_get_paths(destination):
-    # getting paths is async, so let's just retry until we get some
-    while True:
-        try:
-            return sci.paths(destination)
-        except sci.SCIONException:
-            time.sleep(0.1)
 
 
 def parse_tasks_from_stdin():

--- a/example/pyscion.py
+++ b/example/pyscion.py
@@ -4,7 +4,7 @@ The API consists of:
 - set_log_level(level)
 - init()
 - addr = local_address()
-- paths = paths(destination)
+- paths = get_paths(destination)
 - fd = connect(destination, path)
 - fd.close()
 - fd.write(buffer)
@@ -60,3 +60,7 @@ def paths(destination):
 
 def listen(port):
     return connect(None, None)
+
+
+def get_paths(destination, loop_till_have_paths=True):
+    return paths(destination)

--- a/go/example.py
+++ b/go/example.py
@@ -8,7 +8,7 @@ def main():
     print('Local Address is %s' % local_address())
 
     destination = '17-ffaa:1:a,[127.0.0.1]:12345'
-    p = paths(destination)
+    p = get_paths(destination, loop_till_have_paths=False)
     print('Got %d paths:' % len(p))
     for i in range(len(p)):
         print('[%d] %s' % (i, str(p)))

--- a/go/pyscion.py
+++ b/go/pyscion.py
@@ -1,5 +1,9 @@
 """Rudimentary Python API for SCION: wraps a simplified Go API.
 
+To use this, you need to build scion_api.go, which will give you a .so that
+this file provides bindings for. Place both the .so and this file into the same
+directory, somewhere in your Python path (e.g. into .).
+
 The API consists of:
 - set_log_level(level)
 - init()


### PR DESCRIPTION
While this is a terrible idea with the current implementation, I believe that
having a "block until you get some paths" function in the API makes sense. Thus, I propose this as a temporary workaround -- see the doc string of that function.

(We all know how temporary workarounds work :-) )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab-game/41)
<!-- Reviewable:end -->
